### PR TITLE
Fix/outdate deps

### DIFF
--- a/requirements.datascience.in
+++ b/requirements.datascience.in
@@ -10,7 +10,7 @@ duckdb
 
 # ML
 scikit-learn
-shap
+# shap
 networkx[default]
 
 # Visualization

--- a/requirements.datascience.txt
+++ b/requirements.datascience.txt
@@ -48,7 +48,6 @@ cloudpickle==3.1.1
     #   dask
     #   distributed
     #   polars
-    #   shap
 commonmark==0.9.1
     # via great-tables
 connectorx==0.4.3
@@ -148,8 +147,6 @@ jsonschema-specifications==2025.4.1
     # via jsonschema
 kiwisolver==1.4.8
     # via matplotlib
-llvmlite==0.36.0
-    # via numba
 locket==1.0.0
     # via
     #   distributed
@@ -188,8 +185,6 @@ narwhals==2.0.1
     #   bokeh
 networkx==3.5
     # via -r requirements.datascience.in
-numba==0.53.1
-    # via shap
 numpy==2.3.2
     # via
     #   -r requirements.datascience.in
@@ -201,7 +196,6 @@ numpy==2.3.2
     #   matplotlib
     #   mizani
     #   networkx
-    #   numba
     #   pandas
     #   patsy
     #   plotnine
@@ -210,7 +204,6 @@ numpy==2.3.2
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   shap
     #   statsmodels
     #   tensorboardx
 openpyxl==3.1.5
@@ -226,7 +219,6 @@ packaging==25.0
     #   huggingface-hub
     #   matplotlib
     #   ray
-    #   shap
     #   statsmodels
     #   tensorboardx
 pandas==2.3.1
@@ -243,7 +235,6 @@ pandas==2.3.1
     #   polars
     #   ray
     #   seaborn
-    #   shap
     #   statsmodels
 partd==1.4.2
     # via dask
@@ -329,9 +320,7 @@ rpds-py==0.26.0
     #   jsonschema
     #   referencing
 scikit-learn==1.7.1
-    # via
-    #   -r requirements.datascience.in
-    #   shap
+    # via -r requirements.datascience.in
 scipy==1.16.1
     # via
     #   -r requirements.datascience.in
@@ -340,21 +329,15 @@ scipy==1.16.1
     #   plotnine
     #   scikit-learn
     #   seaborn
-    #   shap
     #   statsmodels
 seaborn==0.13.2
     # via -r requirements.datascience.in
 setuptools==80.9.0
     # via
-    #   numba
     #   zope-event
     #   zope-interface
-shap==0.46.0
-    # via -r requirements.datascience.in
 six==1.17.0
     # via python-dateutil
-slicer==0.0.8
-    # via shap
 sortedcontainers==2.4.0
     # via
     #   distributed
@@ -388,7 +371,6 @@ tqdm==4.67.1
     # via
     #   datasets
     #   huggingface-hub
-    #   shap
 typing-extensions==4.14.1
     # via
     #   adbc-driver-manager

--- a/requirements.jax.txt
+++ b/requirements.jax.txt
@@ -57,7 +57,6 @@ cloudpickle==3.1.1
     #   dask
     #   distributed
     #   polars
-    #   shap
 commonmark==0.9.1
     # via great-tables
 connectorx==0.4.3
@@ -187,8 +186,6 @@ jsonschema-specifications==2025.4.1
     # via jsonschema
 kiwisolver==1.4.8
     # via matplotlib
-llvmlite==0.36.0
-    # via numba
 locket==1.0.0
     # via
     #   distributed
@@ -237,8 +234,6 @@ nest-asyncio==1.6.0
     # via orbax-checkpoint
 networkx==3.5
     # via -r requirements.datascience.in
-numba==0.53.1
-    # via shap
 numpy==2.3.2
     # via
     #   -r requirements.datascience.in
@@ -256,7 +251,6 @@ numpy==2.3.2
     #   mizani
     #   ml-dtypes
     #   networkx
-    #   numba
     #   optax
     #   orbax-checkpoint
     #   pandas
@@ -267,7 +261,6 @@ numpy==2.3.2
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   shap
     #   statsmodels
     #   tensorboardx
     #   tensorstore
@@ -326,7 +319,6 @@ packaging==25.0
     #   huggingface-hub
     #   matplotlib
     #   ray
-    #   shap
     #   statsmodels
     #   tensorboardx
 pandas==2.3.1
@@ -343,7 +335,6 @@ pandas==2.3.1
     #   polars
     #   ray
     #   seaborn
-    #   shap
     #   statsmodels
 partd==1.4.2
     # via dask
@@ -434,9 +425,7 @@ rpds-py==0.26.0
     #   jsonschema
     #   referencing
 scikit-learn==1.7.1
-    # via
-    #   -r requirements.datascience.in
-    #   shap
+    # via -r requirements.datascience.in
 scipy==1.16.1
     # via
     #   -r requirements.datascience.in
@@ -447,25 +436,19 @@ scipy==1.16.1
     #   plotnine
     #   scikit-learn
     #   seaborn
-    #   shap
     #   statsmodels
 seaborn==0.13.2
     # via -r requirements.datascience.in
 setuptools==80.9.0
     # via
     #   chex
-    #   numba
     #   triton
     #   zope-event
     #   zope-interface
-shap==0.46.0
-    # via -r requirements.datascience.in
 simplejson==3.20.1
     # via orbax-checkpoint
 six==1.17.0
     # via python-dateutil
-slicer==0.0.8
-    # via shap
 sortedcontainers==2.4.0
     # via
     #   distributed
@@ -504,7 +487,6 @@ tqdm==4.67.1
     # via
     #   datasets
     #   huggingface-hub
-    #   shap
 treescope==0.1.9
     # via flax
 triton==3.4.0

--- a/requirements.nlp.txt
+++ b/requirements.nlp.txt
@@ -59,7 +59,6 @@ cloudpickle==3.1.1
     #   dask
     #   distributed
     #   polars
-    #   shap
 commonmark==0.9.1
     # via great-tables
 confection==0.1.5
@@ -198,8 +197,6 @@ lightning-utilities==0.15.0
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-llvmlite==0.36.0
-    # via numba
 locket==1.0.0
     # via
     #   distributed
@@ -251,8 +248,6 @@ networkx==3.5
     #   torch
 nltk==3.9.1
     # via -r requirements.nlp.in
-numba==0.53.1
-    # via shap
 numpy==2.3.2
     # via
     #   -r requirements.datascience.in
@@ -267,7 +262,6 @@ numpy==2.3.2
     #   matplotlib
     #   mizani
     #   networkx
-    #   numba
     #   pandas
     #   patsy
     #   plotnine
@@ -276,7 +270,6 @@ numpy==2.3.2
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   shap
     #   spacy
     #   statsmodels
     #   tensorboardx
@@ -337,7 +330,6 @@ packaging==25.0
     #   matplotlib
     #   pytorch-lightning
     #   ray
-    #   shap
     #   spacy
     #   statsmodels
     #   tensorboardx
@@ -359,7 +351,6 @@ pandas==2.3.1
     #   polars
     #   ray
     #   seaborn
-    #   shap
     #   statsmodels
 partd==1.4.2
     # via dask
@@ -470,9 +461,7 @@ rpds-py==0.26.0
 safetensors==0.5.3
     # via transformers
 scikit-learn==1.7.1
-    # via
-    #   -r requirements.datascience.in
-    #   shap
+    # via -r requirements.datascience.in
 scipy==1.16.1
     # via
     #   -r requirements.datascience.in
@@ -482,7 +471,6 @@ scipy==1.16.1
     #   plotnine
     #   scikit-learn
     #   seaborn
-    #   shap
     #   statsmodels
 seaborn==0.13.2
     # via -r requirements.datascience.in
@@ -490,21 +478,16 @@ setuptools==80.9.0
     # via
     #   lightning-utilities
     #   marisa-trie
-    #   numba
     #   spacy
     #   thinc
     #   torch
     #   triton
     #   zope-event
     #   zope-interface
-shap==0.46.0
-    # via -r requirements.datascience.in
 shellingham==1.5.4
     # via typer
 six==1.17.0
     # via python-dateutil
-slicer==0.0.8
-    # via shap
 smart-open==7.3.0.post1
     # via
     #   gensim
@@ -579,7 +562,6 @@ tqdm==4.67.1
     #   lightning
     #   nltk
     #   pytorch-lightning
-    #   shap
     #   spacy
     #   transformers
 transformers==4.54.1

--- a/requirements.torch.txt
+++ b/requirements.torch.txt
@@ -48,7 +48,6 @@ cloudpickle==3.1.1
     #   dask
     #   distributed
     #   polars
-    #   shap
 commonmark==0.9.1
     # via great-tables
 connectorx==0.4.3
@@ -166,8 +165,6 @@ lightning-utilities==0.15.0
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-llvmlite==0.36.0
-    # via numba
 locket==1.0.0
     # via
     #   distributed
@@ -210,8 +207,6 @@ networkx==3.5
     # via
     #   -r requirements.datascience.in
     #   torch
-numba==0.53.1
-    # via shap
 numpy==2.3.2
     # via
     #   -r requirements.datascience.in
@@ -224,7 +219,6 @@ numpy==2.3.2
     #   matplotlib
     #   mizani
     #   networkx
-    #   numba
     #   pandas
     #   patsy
     #   plotnine
@@ -233,7 +227,6 @@ numpy==2.3.2
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   shap
     #   statsmodels
     #   tensorboardx
     #   torchmetrics
@@ -291,7 +284,6 @@ packaging==25.0
     #   matplotlib
     #   pytorch-lightning
     #   ray
-    #   shap
     #   statsmodels
     #   tensorboardx
     #   torchmetrics
@@ -309,7 +301,6 @@ pandas==2.3.1
     #   polars
     #   ray
     #   seaborn
-    #   shap
     #   statsmodels
 partd==1.4.2
     # via dask
@@ -400,9 +391,7 @@ rpds-py==0.26.0
     #   jsonschema
     #   referencing
 scikit-learn==1.7.1
-    # via
-    #   -r requirements.datascience.in
-    #   shap
+    # via -r requirements.datascience.in
 scipy==1.16.1
     # via
     #   -r requirements.datascience.in
@@ -411,24 +400,18 @@ scipy==1.16.1
     #   plotnine
     #   scikit-learn
     #   seaborn
-    #   shap
     #   statsmodels
 seaborn==0.13.2
     # via -r requirements.datascience.in
 setuptools==80.9.0
     # via
     #   lightning-utilities
-    #   numba
     #   torch
     #   triton
     #   zope-event
     #   zope-interface
-shap==0.46.0
-    # via -r requirements.datascience.in
 six==1.17.0
     # via python-dateutil
-slicer==0.0.8
-    # via shap
 sortedcontainers==2.4.0
     # via
     #   distributed
@@ -482,7 +465,6 @@ tqdm==4.67.1
     #   huggingface-hub
     #   lightning
     #   pytorch-lightning
-    #   shap
 triton==3.3.1
     # via
     #   -r requirements.torch.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,6 @@ cloudpickle==3.1.1
     #   dask
     #   distributed
     #   polars
-    #   shap
 commonmark==0.9.1
     # via great-tables
 confection==0.1.5
@@ -251,8 +250,6 @@ lightning-utilities==0.15.0
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-llvmlite==0.36.0
-    # via numba
 locket==1.0.0
     # via
     #   distributed
@@ -314,8 +311,6 @@ networkx==3.5
     #   torch
 nltk==3.9.1
     # via -r requirements.nlp.in
-numba==0.53.1
-    # via shap
 numpy==2.3.2
     # via
     #   -r requirements.datascience.in
@@ -339,7 +334,6 @@ numpy==2.3.2
     #   mizani
     #   ml-dtypes
     #   networkx
-    #   numba
     #   opencv-python-headless
     #   optax
     #   orbax-checkpoint
@@ -351,7 +345,6 @@ numpy==2.3.2
     #   scikit-learn
     #   scipy
     #   seaborn
-    #   shap
     #   spacy
     #   statsmodels
     #   tensorboardx
@@ -438,7 +431,6 @@ packaging==25.0
     #   matplotlib
     #   pytorch-lightning
     #   ray
-    #   shap
     #   spacy
     #   statsmodels
     #   tensorboardx
@@ -460,7 +452,6 @@ pandas==2.3.1
     #   polars
     #   ray
     #   seaborn
-    #   shap
     #   statsmodels
 partd==1.4.2
     # via dask
@@ -588,9 +579,7 @@ safetensors==0.5.3
     #   timm
     #   transformers
 scikit-learn==1.7.1
-    # via
-    #   -r requirements.datascience.in
-    #   shap
+    # via -r requirements.datascience.in
 scipy==1.16.1
     # via
     #   -r requirements.datascience.in
@@ -603,7 +592,6 @@ scipy==1.16.1
     #   plotnine
     #   scikit-learn
     #   seaborn
-    #   shap
     #   statsmodels
 seaborn==0.13.2
     # via -r requirements.datascience.in
@@ -612,14 +600,11 @@ setuptools==80.9.0
     #   chex
     #   lightning-utilities
     #   marisa-trie
-    #   numba
     #   spacy
     #   thinc
     #   torch
     #   zope-event
     #   zope-interface
-shap==0.46.0
-    # via -r requirements.datascience.in
 shellingham==1.5.4
     # via typer
 simplejson==3.20.1
@@ -628,8 +613,6 @@ simsimd==6.5.0
     # via albucore
 six==1.17.0
     # via python-dateutil
-slicer==0.0.8
-    # via shap
 smart-open==7.3.0.post1
     # via
     #   gensim
@@ -718,7 +701,6 @@ tqdm==4.67.1
     #   lightning
     #   nltk
     #   pytorch-lightning
-    #   shap
     #   spacy
     #   transformers
 transformers==4.54.1


### PR DESCRIPTION
This pull request primarily removes the `shap` library and its dependencies, such as `numba` and `slicer`, from various requirements files across multiple projects (`datascience`, `jax`, `nlp`, and `torch`). This cleanup eliminates unused or unnecessary dependencies to streamline the dependency management.

### Removal of `shap` and related dependencies:

* Removed `shap` from all requirements files (`requirements.datascience.in`, `requirements.datascience.txt`, `requirements.jax.txt`, `requirements.nlp.txt`, `requirements.torch.txt`). [[1]](diffhunk://#diff-e14f95f8c34df61ee0be18f39b76a96a5dde3f51c405287df8cff0f525c7c9f4L13-R13) [[2]](diffhunk://#diff-e0555f0221c73a96aa2e4d9cfee8a18bd83744a5f1a0629182f30c4ac7a16536L343-L357) [[3]](diffhunk://#diff-9ecd78b91eba940c4c5e0ff7d28177dc9c9f1fff325f3eb6626645de255aa2c2L450-L468) [[4]](diffhunk://#diff-147ee3b4cbc8a31c414f027bdacfdb21bbd88b13ed418e2e07c21fa4f711f36cL485-L507) [[5]](diffhunk://#diff-c736a3ef530a35a247bf1ecd7978fbbaef2d60d6895f190c20bd4c59621899eeL414-L431)
* Removed `numba` and its dependency `llvmlite` as they were only used by `shap`. [[1]](diffhunk://#diff-e0555f0221c73a96aa2e4d9cfee8a18bd83744a5f1a0629182f30c4ac7a16536L191-L192) [[2]](diffhunk://#diff-e0555f0221c73a96aa2e4d9cfee8a18bd83744a5f1a0629182f30c4ac7a16536L151-L152) [[3]](diffhunk://#diff-9ecd78b91eba940c4c5e0ff7d28177dc9c9f1fff325f3eb6626645de255aa2c2L240-L241) [[4]](diffhunk://#diff-147ee3b4cbc8a31c414f027bdacfdb21bbd88b13ed418e2e07c21fa4f711f36cL254-L255) [[5]](diffhunk://#diff-c736a3ef530a35a247bf1ecd7978fbbaef2d60d6895f190c20bd4c59621899eeL213-L214)
* Removed `slicer`, which was also a dependency of `shap`. [[1]](diffhunk://#diff-e0555f0221c73a96aa2e4d9cfee8a18bd83744a5f1a0629182f30c4ac7a16536L343-L357) [[2]](diffhunk://#diff-9ecd78b91eba940c4c5e0ff7d28177dc9c9f1fff325f3eb6626645de255aa2c2L450-L468) [[3]](diffhunk://#diff-147ee3b4cbc8a31c414f027bdacfdb21bbd88b13ed418e2e07c21fa4f711f36cL485-L507) [[4]](diffhunk://#diff-c736a3ef530a35a247bf1ecd7978fbbaef2d60d6895f190c20bd4c59621899eeL414-L431)

### Cleanup of comments in requirements files:

* Updated comments in all requirements files to reflect the removal of `shap` and its dependencies. This includes removing references to `shap` from dependency chains and clarifying which libraries are still in use. [[1]](diffhunk://#diff-e0555f0221c73a96aa2e4d9cfee8a18bd83744a5f1a0629182f30c4ac7a16536L204) [[2]](diffhunk://#diff-9ecd78b91eba940c4c5e0ff7d28177dc9c9f1fff325f3eb6626645de255aa2c2L259) [[3]](diffhunk://#diff-147ee3b4cbc8a31c414f027bdacfdb21bbd88b13ed418e2e07c21fa4f711f36cL270) [[4]](diffhunk://#diff-c736a3ef530a35a247bf1ecd7978fbbaef2d60d6895f190c20bd4c59621899eeL227)

These changes simplify the dependency graph and reduce potential maintenance overhead by removing unused libraries.